### PR TITLE
chore: fix CI

### DIFF
--- a/.conventional-changelog-lintrc
+++ b/.conventional-changelog-lintrc
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "canonical"
-  ]
-}

--- a/.flowconfig
+++ b/.flowconfig
@@ -3,6 +3,7 @@
 .*/node_modules/config-chain/test/broken.json
 .*/node_modules/npmconf/test/fixtures/package.json
 .*/node_modules/conventional-changelog-core/test/fixtures/_malformation.json
+.*/node_modules/documentation/.*
 .*/__tests__/.*
 
 [include]

--- a/.scripts/lint-commits.sh
+++ b/.scripts/lint-commits.sh
@@ -1,0 +1,25 @@
+# lint-commits.sh
+#!/bin/bash
+set -e
+set -u
+
+if [[ $TRAVIS_PULL_REQUEST_SLUG != "" && $TRAVIS_PULL_REQUEST_SLUG != $TRAVIS_REPO_SLUG ]]; then
+    # This is a Pull Request from a different slug, hence a forked repository
+    git remote add "$TRAVIS_PULL_REQUEST_SLUG" "https://github.com/$TRAVIS_PULL_REQUEST_SLUG.git"
+    git fetch "$TRAVIS_PULL_REQUEST_SLUG"
+
+    # Use the fetched remote pointing to the source clone for comparison
+    TO="$TRAVIS_PULL_REQUEST_SLUG/$TRAVIS_PULL_REQUEST_BRANCH"
+else
+    # This is a Pull Request from the same remote, no clone repository
+    TO=$TRAVIS_COMMIT
+fi
+
+# Lint all commits in the PR
+# - Covers fork pull requests (when TO=slug/branch)
+# - Covers branch pull requests (when TO=branch)
+./node_modules/.bin/commitlint --from="$TRAVIS_BRANCH" --to="$TO"
+
+# Always lint the triggerig commit
+# - Covers direct commits
+./node_modules/.bin/commitlint --from="$TRAVIS_COMMIT"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ node_js:
   - 5
   - 4
 before_install:
+  - git fetch --unshallow
   - npm config set depth 0
   - npm install --global npm@3
 script:
+  - /bin/bash ./.scripts/lint-commits.sh
   - NODE_ENV=development npm run build
   - rm -fr ./dist
   - NODE_ENV=production npm run build
@@ -16,7 +18,6 @@ script:
   - nyc --silent npm run test
   - nyc report --reporter=text-lcov | coveralls
   - nyc check-coverage --lines 90
-  - conventional-changelog-lint --from=HEAD~$(git --no-pager rev-list master..HEAD --count)
 after_success:
   - travis-after-all && ./.scripts/release.sh
 notifications:

--- a/package.json
+++ b/package.json
@@ -24,9 +24,10 @@
     "documentation": "documentation build ./src --format md --access public --output ./API.md && gitdown ./.README/README.md --output-file ./README.md",
     "lint": "eslint ./src ./tests",
     "precommit": "npm run lint && npm run test",
-    "commitmsg": "conventional-changelog-lint -e"
+    "commitmsg": "commitlint -e"
   },
   "devDependencies": {
+    "@commitlint/cli": "3.0.3",
     "babel-cli": "^6.11.4",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-plugin-istanbul": "^2.0.0",
@@ -38,8 +39,6 @@
     "babel-preset-es2015-node4": "^2.1.0",
     "babel-register": "^6.11.6",
     "chai": "^3.5.0",
-    "conventional-changelog-cli": "^1.2.0",
-    "conventional-changelog-lint": "^1.0.1",
     "conventional-changelog-lint-config-canonical": "^1.0.0",
     "conventional-recommended-bump": "^0.3.0",
     "coveralls": "^2.11.12",

--- a/tests/gitinfo.js
+++ b/tests/gitinfo.js
@@ -3,7 +3,7 @@ import path from 'path';
 import {
     expect
 } from 'chai';
-import gitinfo from './../src/gitinfo.js';
+import gitinfo from './../src/gitinfo';
 
 describe('gitinfo', () => {
   let repository;


### PR DESCRIPTION
ignore offending documentation module in .flow
update conventional-changelog-lint to include https://github.com/marionebl/commitlint/issues/13
`conventional-changelog-lint` is now `commitlint`
Copied CI script from http://marionebl.github.io/commitlint/#/guides-ci-setup

connects to broken build https://travis-ci.org/gajus/gitinfo/builds/254646852