### PR TITLE
feat: use config.defaultBranchName when HEAD is detached

### DIFF
--- a/src/gitinfo.js
+++ b/src/gitinfo.js
@@ -64,14 +64,19 @@ export default (userConfig: TypeConfig = {}): Object => {
 
     const head = fs.readFileSync(name, {encoding: 'utf8'});
 
-    const branch = head.match(/^ref: refs\/heads\/(.*)$/m);
+    const match = head.match(/^ref: refs\/heads\/(.*)$/m);
+    const branch = match && match[1];
 
-        /* istanbul ignore next */
-    if (!branch) {
-      throw new Error('Cannot get the current branch name.');
+    if (branch) {
+      return branch;
     }
 
-    return branch[1];
+    if (config.defaultBranchName) {
+      return config.defaultBranchName;
+    }
+
+    /* istanbul ignore next */
+    throw new Error('Cannot get the current branch name.');
   };
 
     /**

--- a/tests/gitinfo.js
+++ b/tests/gitinfo.js
@@ -61,6 +61,21 @@ describe('gitinfo', () => {
         throw Error(err);
       });
     });
+
+    it('fallback to default branch if "You are in \'detached HEAD\' state."', (done) => {
+      writeFileAsync(directory + '/HEAD')('32d1ad0c4b984cfb01b52f0477da528cfd1fe4c8')
+        .then(() => {
+          expect(repository.getRemoteUrl()).to.equal('git@github.com:foo/bar.git');
+
+          return writeFileAsync(directory + '/HEAD')('ref: refs/heads/master');
+        })
+        .then(() => {
+          return done();
+        })
+        .catch((err) => {
+          throw Error(err);
+        });
+    });
   });
   describe('.getUsername()', () => {
     it('returns the username of the repository author', () => {


### PR DESCRIPTION
Fixes https://github.com/gajus/gitdown/issues/36

If the current branch is not found, fallback to `config.defaultBranchName`.

This pr is blocked by failing CI at master. #18.